### PR TITLE
Add dependencies on masonry and imagesloaded.  This ensures that the pro...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,10 @@
 {
   "name": "angular-masonry-directive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./src/angular-masonry-directive.js",
   "dependencies": {
-    "angular": ""
+    "angular": "",
+    "masonry": "latest",
+    "imagesloaded": "latest"
   }
 }

--- a/src/angular-masonry-directive.js
+++ b/src/angular-masonry-directive.js
@@ -11,7 +11,9 @@
                     itemSelector: '.item'
                 }, JSON.parse(attrs.masonry));
 
-                scope.obj = new Masonry(container, options);
+                imagesLoaded( container, function() {
+                  scope.obj = new Masonry(container, options);
+                });
             }
         };
     }).directive('masonryTile', function() {


### PR DESCRIPTION
...per libs have been installed and we do not try to load our tiles until they are _actually_ ready
