### PR TITLE
Removed dependence of update() on debounce (Fixes issue #11)

### DIFF
--- a/src/angular-masonry-directive.js
+++ b/src/angular-masonry-directive.js
@@ -12,37 +12,32 @@
 
                 var masonry = scope.masonry = new Masonry(container, options);
 
-                var debounceTimeout = 0;
                 scope.update = function() {
-                    if (debounceTimeout) {
-                        $timeout.cancel(debounceTimeout);
-                    }
-                    debounceTimeout = $timeout(function() {
-                        debounceTimeout = 0;
-
-                        masonry.reloadItems();
-                        masonry.layout();
-    
-                        elem.children(options.itemSelector).css('visibility', 'visible');
-                    }, 120);
+                    masonry.reloadItems();
+                    masonry.layout();
+                    elem.children(options.itemSelector).css('visibility', 'visible');
                 };
-                
+
                 scope.removeBrick = function() {
                     $timeout(function() {
                         masonry.reloadItems();
                         masonry.layout();
-                   }, 500);
-                };                
-                
+                    }, 500);
+                };
+
                 scope.appendBricks = function(ele) {
                     masonry.appended(ele);
-                };                
-                
+                };
+
                 scope.$on('masonry.layout', function() {
-                    masonry.layout();                 
+                    masonry.layout();
                 });
-                
-                scope.update();
+
+                // wait until images have finished loading for the elements and then update
+                var imgLoad = imagesLoaded(document.querySelectorAll(options.itemSelector));
+                imgLoad.on('always', function (instance) {
+                    scope.update();
+                });
             }
         };
     }).directive('masonryTile', function() {
@@ -53,19 +48,19 @@
                 var master = elem.parent('*[masonry]:first').scope(),
                     update = master.update,
                     removeBrick = master.removeBrick,
-                    appendBricks = master.appendBricks;                    
+                    appendBricks = master.appendBricks;
                 if (update) {
                     imagesLoaded( elem.get(0), update);
                     elem.ready(update);
                 }
                 if (appendBricks) {
                     imagesLoaded( elem.get(0), appendBricks(elem));
-                }                
+                }
                 scope.$on('$destroy', function() {
                     if (removeBrick) {
                         removeBrick();
                     }
-                });                
+                });
             }
         };
     });


### PR DESCRIPTION
Wait until images have finished loading for the tile elements, and then do update() so that the dependence on debounce is removed.
