### PR TITLE
Multiple masonry containers  in single page and imagesLoaded fix

### DIFF
--- a/src/angular-masonry-directive.js
+++ b/src/angular-masonry-directive.js
@@ -4,16 +4,17 @@
     angular.module('masonry', ['ng']).directive('masonry', function($timeout) {
         return {
             restrict: 'AC',
-            link: function(scope, elem, attrs) {
-                var container = elem[0];
+            scope:{},
+            controller: function($scope,$element, $attrs) {
+                var container = $element[0];
                 var options = angular.extend({
                     itemSelector: '.item'
-                }, angular.fromJson(attrs.masonry));
+                }, angular.fromJson($attrs.masonry));
 
-                var masonry = scope.masonry = new Masonry(container, options);
+                var masonry = $scope.masonry = new Masonry(container, options);
 
                 var debounceTimeout = 0;
-                scope.update = function() {
+                this.update = function() {
                     if (debounceTimeout) {
                         $timeout.cancel(debounceTimeout);
                     }
@@ -23,37 +24,38 @@
                         masonry.reloadItems();
                         masonry.layout();
     
-                        elem.children(options.itemSelector).css('visibility', 'visible');
+                        $element.children(options.itemSelector).css('visibility', 'visible');
                     }, 120);
                 };
                 
-                scope.removeBrick = function() {
+                this.removeBrick = function() {
                     $timeout(function() {
                         masonry.reloadItems();
                         masonry.layout();
                    }, 500);
                 };                
                 
-                scope.appendBricks = function(ele) {
+                this.appendBricks = function(ele) {
                     masonry.appended(ele);
                 };                
                 
-                scope.$on('masonry.layout', function() {
+                $scope.$on('masonry.layout', function() {
                     masonry.layout();                 
                 });
                 
-                scope.update();
+                this.update();
             }
         };
     }).directive('masonryTile', function() {
         return {
             restrict: 'AC',
-            link: function(scope, elem) {
+            require:'^masonry',
+            link: function(scope, elem,attrs,masonryCtrl) {
                 elem.css('visibility', 'hidden');
                 var master = elem.parent('*[masonry]:first').scope(),
-                    update = master.update,
-                    removeBrick = master.removeBrick,
-                    appendBricks = master.appendBricks;                    
+                    update = masonryCtrl.update,
+                    removeBrick = masonryCtrl.removeBrick,
+                    appendBricks = masonryCtrl.appendBricks;                    
                 if (update) {
                     imagesLoaded( elem.get(0), update);
                     elem.ready(update);
@@ -70,3 +72,4 @@
         };
     });
 })();
+


### PR DESCRIPTION
As pointed out in issue #27, multiple masonry elements in a single page
do not work. Changes have been made in the js file to facilitate the
same. I’ve tested this in one of my projects and is working fine. 
This also fixes the imagesLoaded not executed problem as pointed out in issue #19. 
